### PR TITLE
Fix SearchIndex stray lines

### DIFF
--- a/FortDocs/Services/SearchIndex.swift
+++ b/FortDocs/Services/SearchIndex.swift
@@ -692,9 +692,7 @@ struct IndexStatistics {
     let indexedDocuments: Int
     let totalIndexEntries: Int
     let lastUpdate: Date?
-}moveDocumentFromIndex(document)
-        indexDocument(document)
-    }
+}
     
     func clearAllIndexes() {
         // This will be fully implemented in phase 6
@@ -723,5 +721,3 @@ struct IndexStatistics {
             print("Failed to reindex documents: \(error)")
         }
     }
-}
-


### PR DESCRIPTION
## Summary
- remove stray lines after the `IndexStatistics` struct
- drop an extra closing brace at the file end
- verify compilation with `swiftc -parse`

## Testing
- `swiftc -parse FortDocs/Services/SearchIndex.swift`

------
https://chatgpt.com/codex/tasks/task_e_6881dfa322948330a55558bb0e6ad5f7