### PR TITLE
Fix document file path handling

### DIFF
--- a/FortDocs/Services/CloudKitService.swift
+++ b/FortDocs/Services/CloudKitService.swift
@@ -374,11 +374,10 @@ class CloudKitService: ObservableObject {
             record["folder"] = folderReference
         }
         
-        // Upload file asset
-        if let fileURL = document.fileURL {
-            let asset = CKAsset(fileURL: fileURL)
-            record["fileAsset"] = asset
-        }
+        // Upload file asset using encrypted file path
+        let fileURL = URL(fileURLWithPath: document.encryptedFilePath)
+        let asset = CKAsset(fileURL: fileURL)
+        record["fileAsset"] = asset
         
         try await privateDatabase.save(record)
     }
@@ -398,9 +397,9 @@ class CloudKitService: ObservableObject {
             // Write encrypted file
             try CryptoVault.shared.encryptData(data, to: localURL)
             
-            // Update document with local URL
+            // Update document with local path
             await MainActor.run {
-                document.fileURL = localURL
+                document.encryptedFilePath = localURL.path
             }
             
         } catch {

--- a/FortDocs/Utils/Extensions.swift
+++ b/FortDocs/Utils/Extensions.swift
@@ -320,7 +320,8 @@ extension Document {
     }
     
     func getDecryptedFileURL() throws -> URL {
-        return try CryptoVault.shared.getDecryptedFileURL(for: fileURL)
+        let encryptedURL = URL(fileURLWithPath: encryptedFilePath)
+        return try CryptoVault.shared.getDecryptedFileURL(for: encryptedURL)
     }
 }
 

--- a/FortDocs/Views/ScannerView.swift
+++ b/FortDocs/Views/ScannerView.swift
@@ -438,9 +438,9 @@ struct ProcessingResultsView: View {
         // Clean up temp file
         try? FileManager.default.removeItem(at: tempURL)
         
-        // Set file size
+        // Set file size and encrypted path
         document.fileSize = Int64(imageData.count)
-        document.fileURL = imageURL
+        document.encryptedFilePath = imageURL.path
         
         // Save context
         try viewContext.save()


### PR DESCRIPTION
## Summary
- update CloudKitService to use `encryptedFilePath`
- adjust `getDecryptedFileURL` extension
- store encrypted path when scanning documents

## Testing
- `swiftlint --version` *(fails: command not found)*
- `fastlane --version` *(fails: command not found)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881dfa28d3c8330a02b883544dd0678