### PR TITLE
Refactor DocumentModel vault access

### DIFF
--- a/FortDocs/Models/DocumentModel.swift
+++ b/FortDocs/Models/DocumentModel.swift
@@ -131,10 +131,10 @@ extension Document {
     // MARK: - File Management
     
     func getDecryptedFileURL() throws -> URL {
-        guard let cryptoVault = CryptoVault.shared else {
-            throw DocumentError.cryptoVaultNotAvailable
-        }
-        
+        // Directly access the shared vault. If this ever becomes optional,
+        // callers can throw `cryptoVaultNotAvailable` when `shared` is nil.
+        let cryptoVault = CryptoVault.shared
+
         let encryptedURL = URL(fileURLWithPath: encryptedFilePath)
         return try cryptoVault.getDecryptedFileURL(for: encryptedURL)
     }


### PR DESCRIPTION
## Summary
- access `CryptoVault` without optional binding

## Testing
- `swift -e 'class A {}; let a = A(); print(a as A? == nil)'`

------
https://chatgpt.com/codex/tasks/task_e_6881dfa15a708330a7c8a6408cc15e0a