### PR TITLE
Consolidate file format enum

### DIFF
--- a/FortDocs/Models/DocumentModel.swift
+++ b/FortDocs/Models/DocumentModel.swift
@@ -67,54 +67,6 @@ extension Document {
     }
 }
 
-// MARK: - Document Type Enumeration
-
-enum DocumentType: String, CaseIterable {
-    case pdf = "PDF"
-    case image = "Image"
-    case text = "Text"
-    case unknown = "Unknown"
-    
-    static func from(mimeType: String) -> DocumentType {
-        switch mimeType.lowercased() {
-        case "application/pdf":
-            return .pdf
-        case let type where type.hasPrefix("image/"):
-            return .image
-        case let type where type.hasPrefix("text/"):
-            return .text
-        default:
-            return .unknown
-        }
-    }
-    
-    var icon: String {
-        switch self {
-        case .pdf:
-            return "doc.fill"
-        case .image:
-            return "photo.fill"
-        case .text:
-            return "doc.text.fill"
-        case .unknown:
-            return "doc.fill"
-        }
-    }
-    
-    var color: Color {
-        switch self {
-        case .pdf:
-            return .red
-        case .image:
-            return .green
-        case .text:
-            return .blue
-        case .unknown:
-            return .gray
-        }
-    }
-}
-
 // MARK: - Document Extensions
 
 extension Document {

--- a/FortDocs/Services/DocumentScanner.swift
+++ b/FortDocs/Services/DocumentScanner.swift
@@ -494,7 +494,7 @@ private class DocumentClassifier {
         let lowercasedText = text.lowercased()
         
         // Define classification rules
-        let classifications: [(DocumentType, [String], Double)] = [
+        let classifications: [(DocumentCategory, [String], Double)] = [
             (.invoice, ["invoice", "bill", "billing", "payment due", "amount due", "inv#"], 0.8),
             (.receipt, ["receipt", "thank you", "total", "subtotal", "tax", "change"], 0.7),
             (.identity, ["driver license", "passport", "id card", "identification", "date of birth"], 0.9),
@@ -536,7 +536,7 @@ private class DocumentClassifier {
         )
     }
     
-    private func generateTitle(for type: DocumentType, from text: String) -> String {
+    private func generateTitle(for type: DocumentCategory, from text: String) -> String {
         let lines = text.components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespacesAndPunctuationMarks) }
             .filter { !$0.isEmpty }
@@ -615,14 +615,14 @@ struct TextBlock {
 }
 
 struct DocumentClassification {
-    let type: DocumentType
+    let type: DocumentCategory
     let confidence: Double
     let suggestedTitle: String
     let suggestedFolder: String
     let extractedKeywords: [String]
 }
 
-enum DocumentType {
+enum DocumentCategory {
     case invoice
     case receipt
     case identity


### PR DESCRIPTION
## Summary
- centralize `DocumentType` enumeration in `Extensions.swift`
- remove duplicate enum from `DocumentModel.swift`
- rename scanner classification enum to `DocumentCategory`

## Testing
- `fastlane test` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6881de9cec248330863abc92a39cb61d