### PR TITLE
Implement security and progress improvements

### DIFF
--- a/FortDocs/Services/AuthenticationService.swift
+++ b/FortDocs/Services/AuthenticationService.swift
@@ -373,7 +373,16 @@ private class KeychainService {
             throw AuthenticationError.keychainError(status)
         }
         
-        return storedData == hashedData
+        return timingSafeEqual(storedData, hashedData)
+    }
+
+    private func timingSafeEqual(_ lhs: Data, _ rhs: Data) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        var difference: UInt8 = 0
+        for i in 0..<lhs.count {
+            difference |= lhs[i] ^ rhs[i]
+        }
+        return difference == 0
     }
     
     func hasPIN() -> Bool {

--- a/FortDocs/ViewModels/FolderViewModel.swift
+++ b/FortDocs/ViewModels/FolderViewModel.swift
@@ -71,7 +71,7 @@ class FolderViewModel: ObservableObject {
         do {
             try context.save()
             loadRootFolders(context: context)
-            SearchIndex.shared.reindexAllDocuments(context: context)
+            Task { await SearchIndex.shared.reindexAllDocuments() }
             errorMessage = nil
         } catch {
             errorMessage = "Failed to create folder: \(error.localizedDescription)"
@@ -114,7 +114,7 @@ class FolderViewModel: ObservableObject {
         do {
             try context.save()
             loadRootFolders(context: context)
-            SearchIndex.shared.reindexAllDocuments(context: context)
+            Task { await SearchIndex.shared.reindexAllDocuments() }
             errorMessage = nil
         } catch {
             errorMessage = "Failed to move folder: \(error.localizedDescription)"
@@ -140,7 +140,7 @@ class FolderViewModel: ObservableObject {
         do {
             try context.save()
             loadRootFolders(context: context)
-            SearchIndex.shared.reindexAllDocuments(context: context)
+            Task { await SearchIndex.shared.reindexAllDocuments() }
             errorMessage = nil
         } catch {
             errorMessage = "Failed to rename folder: \(error.localizedDescription)"

--- a/FortDocs/ViewModels/SearchViewModel.swift
+++ b/FortDocs/ViewModels/SearchViewModel.swift
@@ -206,26 +206,26 @@ class SearchViewModel: ObservableObject {
         
         for term in searchTerms {
             var termPredicates: [NSPredicate] = []
-            
-            let options: NSComparisonPredicate.Options = caseSensitive ? [] : [.caseInsensitive]
+
+            let comparisonFlag = caseSensitive ? "" : "[c]"
+            let format = wholeWordsOnly ? "MATCHES\(comparisonFlag)" : "CONTAINS\(comparisonFlag)"
             let escaped = NSRegularExpression.escapedPattern(for: term)
-            let format = wholeWordsOnly ? "MATCHES" : "CONTAINS"
             let pattern = wholeWordsOnly ? ".*\\b\(escaped)\\b.*" : escaped
-            
+
             // Search in title
-            termPredicates.append(NSPredicate(format: "title \(format)[\(options.rawValue)] %@", pattern))
-            
+            termPredicates.append(NSPredicate(format: "title \(format) %@", pattern))
+
             // Search in filename
-            termPredicates.append(NSPredicate(format: "fileName \(format)[\(options.rawValue)] %@", pattern))
-            
+            termPredicates.append(NSPredicate(format: "fileName \(format) %@", pattern))
+
             // Search in OCR text if enabled
             if includeOCRText {
-                termPredicates.append(NSPredicate(format: "ocrText \(format)[\(options.rawValue)] %@", pattern))
+                termPredicates.append(NSPredicate(format: "ocrText \(format) %@", pattern))
             }
-            
+
             // Search in tags
-            termPredicates.append(NSPredicate(format: "ANY tags \(format)[\(options.rawValue)] %@", pattern))
-            
+            termPredicates.append(NSPredicate(format: "ANY tags \(format) %@", pattern))
+
             predicates.append(NSCompoundPredicate(orPredicateWithSubpredicates: termPredicates))
         }
         

--- a/FortDocs/Views/SearchView.swift
+++ b/FortDocs/Views/SearchView.swift
@@ -4,6 +4,7 @@ import CoreData
 struct SearchView: View {
     @Environment(\.managedObjectContext) private var viewContext
     @StateObject private var viewModel = SearchViewModel()
+    @ObservedObject private var searchIndex = SearchIndex.shared
     @State private var searchText = ""
     @State private var selectedDocument: Document?
     @State private var showingFilters = false
@@ -34,6 +35,10 @@ struct SearchView: View {
                         searchText: searchText,
                         selectedDocument: $selectedDocument
                     )
+                }
+                if searchIndex.isIndexing {
+                    ProgressView("Indexing...", value: searchIndex.indexingProgress)
+                        .padding()
                 }
             }
             .navigationTitle("Search")


### PR DESCRIPTION
## Summary
- harden search predicate logic and escape text
- move index management inside `SearchIndex` and make async
- use async reindexing from `FolderViewModel`
- show sync and indexing progress in the UI
- trigger real manual sync and notify user on completion
- manage background tasks more safely
- add constant-time PIN comparison

## Testing
- `fastlane test` *(fails: Git repository is dirty / environment lacks Xcode)*

------
https://chatgpt.com/codex/tasks/task_e_6881e220395c8330bcbcab18ff7d0c77